### PR TITLE
moves to debian stretch for php7 support natively in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM z3cka/c9:stretch
 MAINTAINER Casey Grzecka <c@sey.gr>
 
 RUN apt update
-RUN apt install -y php7.0 php7.0-dev php-pear autoconf automake curl libcurl3-openssl-dev build-essential libxslt1-dev re2c libxml2 libxml2-dev php7.0-cli php7.0-curl bison libbz2-dev libreadline-dev
+RUN apt install -y php7.0 php7.0-dev php-pear autoconf automake curl libcurl3-openssl-dev libcurl4-gnutls-dev build-essential libxslt1-dev re2c libxml2 libxml2-dev php7.0-cli php7.0-curl bison libbz2-dev libreadline-dev
 RUN apt install -y libfreetype6 libfreetype6-dev libjpeg-dev libgd-dev libgd3 libxpm4 libltdl7 libltdl-dev
 RUN apt install -y libssl-dev openssl
 RUN apt install -y gettext libgettextpo-dev libgettextpo0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # c9+php
-FROM z3cka/c9
+FROM z3cka/c9:stretch
 MAINTAINER Casey Grzecka <c@sey.gr>
 
 RUN apt update
-RUN apt install -y php5 php5-dev php-pear autoconf automake curl libcurl3-openssl-dev build-essential libxslt1-dev re2c libxml2 libxml2-dev php5-cli php5-curl bison libbz2-dev libreadline-dev
-RUN apt install -y libfreetype6 libfreetype6-dev libpng12-0 libpng12-dev libjpeg-dev libgd-dev libgd3 libxpm4 libltdl7 libltdl-dev
+RUN apt install -y php7.0 php7.0-dev php-pear autoconf automake curl libcurl3-openssl-dev build-essential libxslt1-dev re2c libxml2 libxml2-dev php7.0-cli php7.0-curl bison libbz2-dev libreadline-dev
+RUN apt install -y libfreetype6 libfreetype6-dev libjpeg-dev libgd-dev libgd3 libxpm4 libltdl7 libltdl-dev
 RUN apt install -y libssl-dev openssl
 RUN apt install -y gettext libgettextpo-dev libgettextpo0
 RUN apt install -y libicu-dev
@@ -22,9 +22,9 @@ RUN phpbrew app get composer
 RUN ln -s /root/.phpbrew/bin/composer /usr/local/bin/composer
 
 RUN pecl install xdebug
-RUN echo "zend_extension=/usr/lib/php5/20131226/xdebug.so" >> /etc/php5/mods-available/xdebug.init
-RUN echo "xdebug.remote_enable=1" >> /etc/php5/mods-available/xdebug.init
-RUN ln -s /etc/php5/mods-available/xdebug.init /etc/php5/cli/conf.d/30-xdebug.ini
+RUN echo "zend_extension=/usr/lib/php/20151012/xdebug.so" >> /etc/php/7.0/mods-available/xdebug.init
+RUN echo "xdebug.remote_enable=1" >> /etc/php/7.0/mods-available/xdebug.init
+RUN ln -s /etc/php/7.0/mods-available/xdebug.init /etc/php/7.0/cli/conf.d/30-xdebug.ini
 
 EXPOSE 80
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # c9 w/ php
-c9 container with php via phpbrew
+
+c9 _(Cloud9)_ with php via phpbrew based on [z3cka/c9/](https://hub.docker.com/r/z3cka/c9/)


### PR DESCRIPTION
Resolves #1. I will wait to merge the PR until i know I can successfully build and use downstream in https://hub.docker.com/r/z3cka/c9-phpbrew-drupal/builds/